### PR TITLE
Fix missing seq `area_city_id_seq` issue

### DIFF
--- a/db/area_city.sql
+++ b/db/area_city.sql
@@ -20,7 +20,7 @@ Date: 2020-02-17 13:21:46
 -- ----------------------------
 DROP TABLE IF EXISTS "public"."area_city";
 CREATE TABLE "public"."area_city" (
-"id" int4 DEFAULT nextval('area_city_id_seq') PRIMARY KEY,
+"id" SERIAL PRIMARY KEY,
 "curday" date,
 "city_name" varchar(255) COLLATE "default",
 "city_code" int4,

--- a/db/area_province.sql
+++ b/db/area_province.sql
@@ -20,7 +20,7 @@ Date: 2020-02-17 13:22:02
 -- ----------------------------
 DROP TABLE IF EXISTS "public"."area_province";
 CREATE TABLE "public"."area_province" (
-"id" int4 DEFAULT nextval('area_province_id_seq') PRIMARY KEY,
+"id" SERIAL PRIMARY KEY,
 "curday" date,
 "province_name" varchar(255) COLLATE "default",
 "province_code" int4,


### PR DESCRIPTION
Test the DB schema creation as well as data insertion flows with local DB

1. create `wuhandb` 
2. create schema `psql -h localhost -U postgres -d wuhandb -a -f {area_city, area_province, area_relation}.sql`
3. populate data, `psql -h localhost -U postgres -d wuhandb -a -f data/{area_city_data, area_province_data}.sql`

Some results:
```
wuhandb-# \dt public.*
             List of relations
 Schema |     Name      | Type  |  Owner
--------+---------------+-------+----------
 public | area_city     | table | postgres
 public | area_province | table | postgres
 public | area_relation | table | postgres
(3 rows)

wuhandb=# select count(*) from area_city;
 count
-------
  6444
(1 row)

wuhandb=# select count(*) from area_province;
 count
-------
   774
(1 row)
```